### PR TITLE
Specify build script is bash only

### DIFF
--- a/build-image.sh
+++ b/build-image.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 


### PR DESCRIPTION
Changing shebang to bash because build script requires pushd, which is a bash enhancement.

https://stackoverflow.com/questions/5193048/bin-sh-pushd-not-found